### PR TITLE
Fix homepage link and capitalization of GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 > Randomly generates recipes using the power of machine learning
 
-### 🏠 [Homepage](thisrecipedoesnotexist.com)
+### 🏠 [Homepage](https://thisrecipedoesnotexist.com)
 
 ## Author
 
 👤 **John Hollingsworth**
 
 * Twitter: [@DoesRecipe](https://twitter.com/DoesRecipe)
-* Github: [@Hollings](https://github.com/Hollings)
+* GitHub: [@Hollings](https://github.com/Hollings)
 
 ## Show your support
 

--- a/site/resources/views/home.blade.php
+++ b/site/resources/views/home.blade.php
@@ -166,7 +166,7 @@
 
 </div>
 <div class='footer'>Recipe generated {{$r->created_at}} | {{ $freshRecipeCount }} fresh recipes left | <strong><a
-                class="text-success" href="https://github.com/Hollings/thisrecipedoesnotexist">Github</a> | <a
+                class="text-success" href="https://github.com/Hollings/thisrecipedoesnotexist">GitHub</a> | <a
                 class="text-success" href="https://twitter.com/DoesRecipe">Twitter</a></strong>
 </div>
 


### PR DESCRIPTION
Turns out that GitHub interprets all (?) URLs without protocols as relative